### PR TITLE
Fix: Remember move when building Query

### DIFF
--- a/src/main/java/xyz/niflheim/stockfish/engine/enums/Query.java
+++ b/src/main/java/xyz/niflheim/stockfish/engine/enums/Query.java
@@ -20,9 +20,10 @@ public class Query {
     private int difficulty, depth;
     private long movetime;
 
-    public Query(QueryType type, String fen, int difficulty, int depth, long movetime) {
+    public Query(QueryType type, String fen, String move, int difficulty, int depth, long movetime) {
         this.type = type;
         this.fen = fen;
+        this.move = move;
         this.difficulty = difficulty;
         this.depth = depth;
         this.movetime = movetime;
@@ -94,7 +95,7 @@ public class Query {
             if (fen == null)
                 throw new IllegalStateException("Query is missing FEN.");
 
-            return new Query(type, fen, difficulty, depth, movetime);
+            return new Query(type, fen, move, difficulty, depth, movetime);
         }
     }
 }


### PR DESCRIPTION
First, thank you for this handy wrapper! :)

I noticed that using `Make_Move` did not seem to have an effect, it just returned the board described by the fen argument as in the following example:
``` Java
client.submit(new Query.Builder(QueryType.Make_Move)
  .setFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
  .setMove("e2e4")
  .build(), result -> System.out.println(result));

// Output: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
```
I found out that in the constructor of `Query`, the field `move` is not set. This means that any move set by `setMove()` is not part of the `Query` and therefore not sent to Stockfish. I changed the constructor and its only caller such that (1) the value in `Query.move` is sent as a parameter to the constructor, and that (2) the constructor uses the parameter by storing it in `Query.move`.



